### PR TITLE
Tileクラスと道の形を保持する配列を作成

### DIFF
--- a/MazeGenerator/Tile/Edge.java
+++ b/MazeGenerator/Tile/Edge.java
@@ -1,0 +1,29 @@
+package Tile;
+
+public class Edge extends Tile {
+    public Edge() {
+        block = new boolean[][][]{
+                { // default
+                        {false, false, false},
+                        {false, true, false},
+                        {false, true, false}
+                },
+                { // right
+                        {false, false, false},
+                        {true, true, true},
+                        {false, false, false}
+                },
+                { // left
+                        {false, false, false},
+                        {false, true, true},
+                        {false, false, false}
+                },
+                { // reverse
+                        {false, true, false},
+                        {false, true, false},
+                        {false, false, false}
+                }
+        };
+    }
+}
+

--- a/MazeGenerator/Tile/Edge.java
+++ b/MazeGenerator/Tile/Edge.java
@@ -1,4 +1,4 @@
-package Tile;
+package MazeGenerator.Tile;
 
 public class Edge extends Tile {
     public Edge() {

--- a/MazeGenerator/Tile/LoadI.java
+++ b/MazeGenerator/Tile/LoadI.java
@@ -1,4 +1,4 @@
-package Tile;
+package MazeGenerator.Tile;
 
 public class LoadI extends Tile {
     public LoadI() {

--- a/MazeGenerator/Tile/LoadI.java
+++ b/MazeGenerator/Tile/LoadI.java
@@ -1,0 +1,28 @@
+package Tile;
+
+public class LoadI extends Tile {
+    public LoadI() {
+        block = new boolean[][][]{
+                { // default
+                        {false, true, false},
+                        {false, true, false},
+                        {false, true, false}
+                },
+                { // right
+                        {false, false, false},
+                        {true, true, true},
+                        {false, false, false}
+                },
+                { // left
+                        {false, false, false},
+                        {true, true, true},
+                        {false, false, false}
+                },
+                { // reverse
+                        {false, true, false},
+                        {false, true, false},
+                        {false, true, false}
+                }
+        };
+    }
+}

--- a/MazeGenerator/Tile/LoadL.java
+++ b/MazeGenerator/Tile/LoadL.java
@@ -1,4 +1,4 @@
-package Tile;
+package MazeGenerator.Tile;
 
 public class LoadL extends Tile {
     public LoadL() {

--- a/MazeGenerator/Tile/LoadL.java
+++ b/MazeGenerator/Tile/LoadL.java
@@ -1,0 +1,28 @@
+package Tile;
+
+public class LoadL extends Tile {
+    public LoadL() {
+        block = new boolean[][][]{
+                { // default
+                        {false, true, false},
+                        {false, true, true},
+                        {false, false, false}
+                },
+                { // right
+                        {false, true, false},
+                        {true, true, false},
+                        {false, false, false}
+                },
+                { // left
+                        {false, false, false},
+                        {false, true, true},
+                        {false, true, true}
+                },
+                { // reverse
+                        {false, false, false},
+                        {true, true, false},
+                        {false, true, false}
+                }
+        };
+    }
+}

--- a/MazeGenerator/Tile/LoadT.java
+++ b/MazeGenerator/Tile/LoadT.java
@@ -1,4 +1,4 @@
-package Tile;
+package MazeGenerator.Tile;
 
 public class LoadT extends Tile {
     public LoadT() {

--- a/MazeGenerator/Tile/LoadT.java
+++ b/MazeGenerator/Tile/LoadT.java
@@ -1,0 +1,28 @@
+package Tile;
+
+public class LoadT extends Tile {
+    public LoadT() {
+        block = new boolean[][][]{
+                { // default
+                        {false, false, false},
+                        {true, true, true},
+                        {false, true, false}
+                },
+                { // right
+                        {false, true, false},
+                        {false, true, true},
+                        {false, true, false}
+                },
+                { // left
+                        {false, true, false},
+                        {true, true, false},
+                        {false, true, false}
+                },
+                { // reverse
+                        {false, true, false},
+                        {true, true, true},
+                        {false, false, false}
+                }
+        };
+    }
+}

--- a/MazeGenerator/Tile/LoadX.java
+++ b/MazeGenerator/Tile/LoadX.java
@@ -1,4 +1,4 @@
-package Tile;
+package MazeGenerator.Tile;
 
 public class LoadX extends Tile {
     public LoadX() {

--- a/MazeGenerator/Tile/LoadX.java
+++ b/MazeGenerator/Tile/LoadX.java
@@ -1,0 +1,28 @@
+package Tile;
+
+public class LoadX extends Tile {
+    public LoadX() {
+        block = new boolean[][][]{
+                { // default
+                        {false, true, false},
+                        {true, true, true},
+                        {false, true, false}
+                },
+                { // right
+                        {false, true, false},
+                        {true, true, true},
+                        {false, true, false}
+                },
+                { // left
+                        {false, true, false},
+                        {true, true, true},
+                        {false, true, false}
+                },
+                { // reverse
+                        {false, true, false},
+                        {true, true, true},
+                        {false, true, false}
+                }
+        };
+    }
+}

--- a/MazeGenerator/Tile/Tile.java
+++ b/MazeGenerator/Tile/Tile.java
@@ -4,5 +4,7 @@ abstract public class Tile{
   protected int rotate;
   protected boolean[][][] block;
   
-  
+  boolean block(int rotate,int row,int column){
+    return block[rotate][row][column];
+  }
 }

--- a/MazeGenerator/Tile/Tile.java
+++ b/MazeGenerator/Tile/Tile.java
@@ -1,4 +1,4 @@
-package Tile;
+package MazeGenerator.Tile;
 
 abstract public class Tile{
   protected int rotate;

--- a/MazeGenerator/Tile/Tile.java
+++ b/MazeGenerator/Tile/Tile.java
@@ -1,0 +1,8 @@
+package Tile;
+
+abstract public class Tile{
+  protected int rotate;
+  protected boolean[][][] block;
+  
+  
+}


### PR DESCRIPTION
各タイルの親となるTileクラスを作成する。
各道はTileクラスを継承し、配列に形を設定する。
配列は4x3x3で左から[向き][縦][横]を意味する。
メインの処理からは各道のコンストラクタを呼び出すことでブロックごとに道の形を処理できる。
現状は形のみで回転や形の受け渡しのメソッドはこれから実装する。